### PR TITLE
Prevent crashes on recursive folder delete and multiple folder add

### DIFF
--- a/fsevents.py
+++ b/fsevents.py
@@ -122,16 +122,20 @@ class FileEventCallback(object):
         events = []
         deleted = {}
 
-        for path in paths:
+        for path in sorted(paths):
             path = path.rstrip('/')
             snapshot = self.snapshots[path]
 
             current = {}
-            for name in os.listdir(path):
-                try:
-                    current[name] = os.stat(os.path.join(path, name))
-                except OSError:
-                    pass
+            try:
+                for name in os.listdir(path):
+                    try:
+                        current[name] = os.stat(os.path.join(path, name))
+                    except OSError:
+                        pass
+            except OSError:
+                # recursive delete causes problems with path being non-existent
+                pass
 
             observed = set(current)
 


### PR DESCRIPTION
If I do `mkdir -p test/one/two/three` and then `rm -rf test` I'd get an error:

```
OSError: [Errno 2] No such file or directory: '/private/var/webdisk/test/one/two/three'
```

This patch guards the os.listdir in a try/catch to ignore any OSError thrown.

There is also a tweak to the outermost loop inside `__call__` in that I have

```
for path in sorted(paths):
```

which prevents crashes when, for the case above, one of the inner folder creations gets 'looked at' too early, and an exception is thrown, i.e.:

```
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/threading.py", line 522, in __bootstrap_inner
    self.run()
  File "/Library/Python/2.6/site-packages/MacFSEvents-0.2.3-py2.6-macosx-10.6-universal.egg/fsevents.py", line 44, in run
    _fsevents.loop(self)
  File "/Library/Python/2.6/site-packages/MacFSEvents-0.2.3-py2.6-macosx-10.6-universal.egg/fsevents.py", line 127, in __call__
    snapshot = self.snapshots[path]
KeyError: '/private/var/webdisk/test/one'
```

where `/private/var/webdisk/` is the folder I'm monitoring.

I'm not seeing of any undesired side-effects in my own use of the modified library, but you're more familiar with the code and maybe there's something I missed. One thing seems to be a somewhat redundant notification of the nested folders being deleted, though maybe that's desirable. Still, I hope this helps.

Cheers and thanks for making this library!
