### PR TITLE
Correcting Move Problem

### DIFF
--- a/fsevents.py
+++ b/fsevents.py
@@ -187,9 +187,7 @@ class FileEventCallback(object):
                         events.append(FileEvent(IN_ATTRIB, None, filename))
                     observed.discard(name)
                 else:
-                    event = None
-                    if (snap_stat):
-                        event = created.get(snap_stat.st_ino)
+                    event = created.get(snap_stat.st_ino)
                     if (event is not None):
                         self.cookie += 1
                         event.mask = IN_MOVED_FROM


### PR DESCRIPTION
The problem was : "Imagine a folder /home/, I have a file in folder /home/toto/ named file1.
If I do : "mv /home/toto/file1 /home/" macfsevent give me a delete and create event instead of move from, move to event."
