### PR TITLE
make use of stream create flags and event ids

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,11 +85,24 @@ To start the observer in the current thread, use the ``run`` method
 
   observer.run()
 
-The callback function will be called when an event occurs. A
-``FileEvent`` instance is passed to the callback and has 3 attributes:
-``mask``, ``cookie`` and ``name``. ``name`` parameter contains the path
-at which the event happened (may be a subdirectory) while ``mask``
-parameter is the event mask [#]_.
+The callback function will be called when an event occurs. 
+Depending on the stream, the callback will have different signitures:
+
+a) the standart stream (with callback and paths) will call callback with
+   parameters callback(path, mask) where path is the directory where a file 
+   changed and mask can be decoded using FS_FLAG* and FS_ITEM* constants [#]_.
+   a convenience class Mask has a __str__ function to get a text representation
+   of the flags.
+b) the stream is created with ``ids`` = True keyword parameter. In this case the call
+   is callback(path, mask, id). The id can be used in the ``since`` keyword
+   parameter of another stream object to also recieve historic events (that
+   happened before the stream became active)
+c) if ``file_events`` is kwarg set to True, a
+   ``FileEvent`` instance is passed to the callback and has 3 attributes:
+   ``mask``, ``cookie`` and ``name``. ``name`` parameter contains the path
+   at which the event happened (may be a subdirectory) while ``mask``
+   parameter is the event mask. this mimicks ``inotify`` behaviour. 
+   see also below.
 
 To stop observation, simply unschedule the stream and stop the
 observer::

--- a/_fsevents.c
+++ b/_fsevents.c
@@ -297,19 +297,6 @@ MOD_INIT(_fsevents) {
     PyModule_AddIntConstant(mod, "FS_CFLAGFILEEVENTS", kFSEventStreamCreateFlagFileEvents);
 
 
-//   /* These flags are only set if you specified the FileEvents */
-//   /* flags when creating the stream.*/
-//    PyModule_AddIntConstant(mod, "FS_FLAGITEMCREATED", kFSEventStreamEventFlagItemCreated);
-//    PyModule_AddIntConstant(mod, "FS_FLAGITEMREMOVED", kFSEventStreamEventFlagItemRemoved);
-//    PyModule_AddIntConstant(mod, "FS_FLAGITEMINODEMETAMOD", kFSEventStreamEventFlagItemInodeMetaMod);
-//    PyModule_AddIntConstant(mod, "FS_FLAGITEMRENAMED", kFSEventStreamEventFlagItemRenamed);
-//    PyModule_AddIntConstant(mod, "FS_FLAGITEMMODIFIED", kFSEventStreamEventFlagItemModified);
-//    PyModule_AddIntConstant(mod, "FS_FLAGITEMFINDERINFOMOD", kFSEventStreamEventFlagItemFinderInfoMod);
-//    PyModule_AddIntConstant(mod, "FS_FLAGITEMCHANGEDOWNER", kFSEventStreamEventFlagItemChangeOwner);
-//    PyModule_AddIntConstant(mod, "FS_FLAGITEMXATTRMOD", kFSEventStreamEventFlagItemXattrMod);
-//    PyModule_AddIntConstant(mod, "FS_FLAGITEMISFILE", kFSEventStreamEventFlagItemIsFile);
-//    PyModule_AddIntConstant(mod, "FS_FLAGITEMISDIR", kFSEventStreamEventFlagItemIsDir);
-//    PyModule_AddIntConstant(mod, "FS_FLAGITEMISSYMLINK", kFSEventStreamEventFlagItemIsSymlink);
 
     loops = PyDict_New();
     streams = PyDict_New();

--- a/fsevents.py
+++ b/fsevents.py
@@ -44,6 +44,7 @@ from _fsevents import (
     )
 
 class Mask(int):
+    __slots__ = 'stringmap', 'svals'
     stringmap = {FS_FLAGMUSTSCANSUBDIRS:    'MustScanSubDirs',
                  FS_FLAGUSERDROPPED:        'UserDropped',
                  FS_FLAGKERNELDROPPED:      'KernelDropped',
@@ -136,7 +137,11 @@ class Observer(threading.Thread):
                 for path, mask, id in zip(paths, masks, ids):
                     if sys.version_info[0] >= 3:
                         path = path.decode('utf-8')
-                    stream.callback(path, Mask(mask), id)
+                    if stream.ids is False:
+                        stream.callback(path, mask)
+                    elif stream.ids is True:
+                        stream.callback(path, mask, id)
+            
         schedule(self, stream, callback, stream.paths, stream.since, stream.latency, stream.cflags)
 
     def schedule(self, stream):
@@ -177,6 +182,7 @@ class Stream(object):
         since = options.pop('since',FS_EVENTIDSINCENOW)
         cflags = options.pop('flags', FS_CFLAGNONE)
         latency = options.pop('latency', 0.01)
+        ids = options.pop('ids', False)
         assert len(options) == 0, "Invalid option(s): %s" % repr(options.keys())
         check_path_string_type(*paths)
 
@@ -193,6 +199,7 @@ class Stream(object):
         self.since = since
         self.cflags = cflags
         self.latency = latency
+        self.ids = ids
 
 class FileEvent(object):
     __slots__ = 'mask', 'cookie', 'name'

--- a/fsevents.py
+++ b/fsevents.py
@@ -22,8 +22,62 @@ from _fsevents import (
     FS_ITEMISFILE,
     FS_ITEMISDIR,
     FS_ITEMISSYMLINK,  
-)
 
+    FS_EVENTIDSINCENOW,
+    
+    FS_FLAGEVENTIDSWRAPPED,
+    FS_FLAGNONE,
+    FS_FLAGHISTORYDONE,
+    FS_FLAGROOTCHANGED,
+    FS_FLAGKERNELDROPPED,
+    FS_FLAGUNMOUNT,
+    FS_FLAGMOUNT,
+    FS_FLAGUSERDROPPED,
+    FS_FLAGMUSTSCANSUBDIRS,
+
+    FS_CFLAGFILEEVENTS,
+    FS_CFLAGNONE,
+    FS_CFLAGIGNORESELF,
+    FS_CFLAGUSECFTYPES,
+    FS_CFLAGNODEFER,
+    FS_CFLAGWATCHROOT,
+    )
+
+class Mask(int):
+    stringmap = {FS_FLAGMUSTSCANSUBDIRS:    'MustScanSubDirs',
+                 FS_FLAGUSERDROPPED:        'UserDropped',
+                 FS_FLAGKERNELDROPPED:      'KernelDropped',
+                 FS_FLAGEVENTIDSWRAPPED:    'EventIDsWrapped',
+                 FS_FLAGHISTORYDONE:        'HistoryDone',
+                 FS_FLAGROOTCHANGED:        'RootChanged',
+                 FS_FLAGMOUNT:              'Mount',
+                 FS_FLAGUNMOUNT:            'Unmount',
+            #         /* flags when creating the stream.*/
+                 FS_ITEMCREATED:            'ItemCreated',
+                 FS_ITEMREMOVED:            'ItemRemoved',
+                 FS_ITEMINODEMETAMOD:       'ItemInodeMetaMod',
+                 FS_ITEMRENAMED:            'ItemRenamed',
+                 FS_ITEMMODIFIED:           'ItemModified',
+                 FS_ITEMFINDERINFOMOD:      'ItemFinderInfoMod',
+                 FS_ITEMCHANGEOWNER:        'ItemChangedOwner',
+                 FS_ITEMXATTRMOD:           'ItemXAttrMod',
+                 FS_ITEMISFILE:             'ItemIsFile',
+                 FS_ITEMISDIR:              'ItemIsDir',
+                 FS_ITEMISSYMLINK:          'ItemIsSymlink'
+                 }
+
+    svals = stringmap.keys()
+    svals.sort()
+    
+    def __str__(self):
+        res = ''
+        for k in self.svals:
+            if self&k:
+                res += self.stringmap[k] + '|'
+        res = res[:-1]
+        res = '['+res+']'
+        return res
+        
 # inotify event flags
 IN_MODIFY = 0x00000002
 IN_ATTRIB = 0x00000004
@@ -78,12 +132,12 @@ class Observer(threading.Thread):
         if stream.file_events:
             callback = FileEventCallback(stream.callback, stream.raw_paths)
         else:
-            def callback(paths, masks):
-                for path, mask in zip(paths, masks):
+            def callback(paths, masks, ids):
+                for path, mask, id in zip(paths, masks, ids):
                     if sys.version_info[0] >= 3:
                         path = path.decode('utf-8')
-                    stream.callback(path, mask)
-        schedule(self, stream, callback, stream.paths)
+                    stream.callback(path, Mask(mask), id)
+        schedule(self, stream, callback, stream.paths, stream.since, stream.latency, stream.cflags)
 
     def schedule(self, stream):
         self.lock.acquire()
@@ -120,6 +174,9 @@ class Observer(threading.Thread):
 class Stream(object):
     def __init__(self, callback, *paths, **options):
         file_events = options.pop('file_events', False)
+        since = options.pop('since',FS_EVENTIDSINCENOW)
+        cflags = options.pop('flags', FS_CFLAGNONE)
+        latency = options.pop('latency', 0.01)
         assert len(options) == 0, "Invalid option(s): %s" % repr(options.keys())
         check_path_string_type(*paths)
 
@@ -133,6 +190,9 @@ class Stream(object):
         ]
 
         self.file_events = file_events
+        self.since = since
+        self.cflags = cflags
+        self.latency = latency
 
 class FileEvent(object):
     __slots__ = 'mask', 'cookie', 'name'
@@ -154,7 +214,7 @@ class FileEventCallback(object):
         self.callback = callback
         self.cookie = 0
 
-    def __call__(self, paths, masks):
+    def __call__(self, paths, masks, ids):
         events = []
         deleted = {}
         created = {}


### PR DESCRIPTION
I have patched your nice peace of code to allow to use stream create flags and event ids. I have tried to do it in a compatible manner (i.e. behaviour is unchanged if the new functionality is not used).

The only thing I changed, is the former default create flag NoDefer is removed as I thought that this is a more consistent behaviour. Check if you like it.