### PR TITLE
supports UTF-8-MAC(NFD)

### DIFF
--- a/fsevents.py
+++ b/fsevents.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import threading
+import unicodedata
 
 from _fsevents import (
     loop,
@@ -160,6 +161,11 @@ class FileEventCallback(object):
         created = {}
 
         for path in sorted(paths):
+            # supports UTF-8-MAC(NFD)
+            if not isinstance(path, unicode):
+                path = path.decode('utf-8')
+            path = unicodedata.normalize('NFD', path).encode('utf-8')
+
             if sys.version_info[0] >= 3:
                 path = path.decode('utf-8')
                 


### PR DESCRIPTION
The Mac OS X has the [HFS+](https://en.wikipedia.org/wiki/HFS_Plus) file system that used file paths in UTF-8-MAC encoding.

The UTF-8-MAC is not same as UTF-8.
The UTF-8 is encoded by Normalization Form C.
The UTF-8-MAC is encoded by Normalization Form D.

ref: [Unicode equivalence](https://en.wikipedia.org/wiki/Unicode_equivalence)

ex)
The "Python" is "パイソン" in Japanese KATA-KANA, cases in UTF-8/UTF-8-MAC:
* u'\u30d1\u30a4\u30bd\u30f3' in UTF-8
* u'\u30cf\u309a\u30a4\u30bd\u30f3' in UTF-8-MAC

These differences will be a problem in Japanese/other file name.