### PR TITLE
fix segfault.

### DIFF
--- a/_fsevents.c
+++ b/_fsevents.c
@@ -135,7 +135,7 @@ static PyObject* pyfsevents_schedule(PyObject* self, PyObject* args) {
     CFTimeInterval latency = 0.01;
     FSEventStreamCreateFlags cflags = kFSEventStreamCreateFlagNone;
 
-    if (!PyArg_ParseTuple(args, "OOOO|KdK:schedule",
+    if (!PyArg_ParseTuple(args, "OOOO|KdI:schedule",
                           &thread, &stream, &callback, &paths, &lastid, &latency, &cflags))
         return NULL;
 


### PR DESCRIPTION
I got the same issue #37 on macOS 10.13 (High Sierra).

I found that `FSEventStreamCreateFlags` is not `unsigned long long` but `unsigned int`.