### PR TITLE
Use build instead of setup.py xxx commands

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,15 +26,16 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - ["3.8",  "py38",      "macos-12"]
-        - ["3.9",  "py38",      "macos-12"]
-        - ["3.9",  "lint",      "macos-12"]
-        - ["3.9",  "py39",      "macos-12"]
-        - ["3.10", "py310",     "macos-12"]
-        - ["3.11", "py311",     "macos-12"]
-        - ["3.12", "py312",     "macos-12"]
-        - ["3.13", "py313",     "macos-13"]
-        - ["3.14", "py314",     "macos-14"]
+        - ["3.8",  "py38",      "macos-15"]
+        - ["3.9",  "py38",      "macos-15"]
+        - ["3.9",  "lint",      "macos-15"]
+        - ["3.9",  "py39",      "macos-15"]
+        - ["3.10", "py310",     "macos-15"]
+        - ["3.11", "py311",     "macos-15"]
+        - ["3.12", "py312",     "macos-15"]
+        - ["3.13", "py313",     "macos-15"]
+        - ["3.14", "py314",     "macos-15"]
+        - ["3.14", "py314",     "macos-26"]
     runs-on: ${{ matrix.config[2] }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[0] }}-${{ matrix.config[1] }}-${{ matrix.config[2] }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         config:
         - ["3.8",  "py38",      "macos-14"]
-        - ["3.9",  "py38",      "macos-14"]
+        - ["3.9",  "py39",      "macos-14"]
         - ["3.9",  "lint",      "macos-14"]
         - ["3.9",  "py39",      "macos-14"]
         - ["3.10", "py310",     "macos-14"]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,11 +8,15 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
-    - run: python -m pip install setuptools wheel
-    - run: python setup.py sdist
-    - run: python setup.py bdist_wheel
-    - uses: actions/upload-artifact@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+      with:
+        python-version: 3.x
+    - run: python -m pip install --upgrade pip
+    - run: pip install build setuptools
+    - run: pip install --editable .
+    - run: python -m build
+    - uses: actions/upload-artifact@v5
       with:
         name: MacFSEvents
         path: ./dist/
@@ -29,20 +33,20 @@ jobs:
         - ["3.10", "py310",     "macos-12"]
         - ["3.11", "py311",     "macos-12"]
         - ["3.12", "py312",     "macos-12"]
-        - ["3.12", "py312",     "macos-13"]
-        - ["3.12", "py312",     "macos-14"]
+        - ["3.13", "py313",     "macos-13"]
+        - ["3.14", "py314",     "macos-14"]
     runs-on: ${{ matrix.config[2] }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[0] }}-${{ matrix.config[1] }}-${{ matrix.config[2] }}
     steps:
     - run: git config --global core.autocrlf false
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.config[0] }}
     - name: Pip cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
         - ["3.12", "py312",     "macos-14"]
         - ["3.13", "py313",     "macos-14"]
         - ["3.14", "py314",     "macos-14"]
+        - ["3.14", "py314",     "macos-15-intel"]
         - ["3.14", "py314",     "macos-15"]
         - ["3.14", "py314",     "macos-26"]
     runs-on: ${{ matrix.config[2] }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,14 +26,15 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - ["3.8",  "py38",      "macos-15"]
-        - ["3.9",  "py38",      "macos-15"]
-        - ["3.9",  "lint",      "macos-15"]
-        - ["3.9",  "py39",      "macos-15"]
-        - ["3.10", "py310",     "macos-15"]
-        - ["3.11", "py311",     "macos-15"]
-        - ["3.12", "py312",     "macos-15"]
-        - ["3.13", "py313",     "macos-15"]
+        - ["3.8",  "py38",      "macos-14"]
+        - ["3.9",  "py38",      "macos-14"]
+        - ["3.9",  "lint",      "macos-14"]
+        - ["3.9",  "py39",      "macos-14"]
+        - ["3.10", "py310",     "macos-14"]
+        - ["3.11", "py311",     "macos-14"]
+        - ["3.12", "py312",     "macos-14"]
+        - ["3.13", "py313",     "macos-14"]
+        - ["3.14", "py314",     "macos-14"]
         - ["3.14", "py314",     "macos-15"]
         - ["3.14", "py314",     "macos-26"]
     runs-on: ${{ matrix.config[2] }}

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,8 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: System :: Filesystems",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@ envlist =
     py310
     py311
     py312
+    py313
+    py314
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
```diff
-    - run: python setup.py sdist
-    - run: python setup.py bdist_wheel
+    - run: python -m build
```
https://packaging.python.org/en/latest/discussions/setup-py-deprecated
> `python setup.py` and the use of `setup.py` as a command line tool are deprecated.
> This means that commands such as the following MUST NOT be run anymore:
> * python setup.py install
> * python setup.py develop
> * python setup.py sdist
> * python setup.py bdist_wheel

Instead, use `build`...  https://github.com/pypa/build

### Why make the proposed changes?
% `uvx --with=MacFSEvents python3.12 -c "import fsevents" ` # --> Works!!

But changing `python3.12` to `3.13`, `3.14`, or `3.14t` fails!

--- 
Replace GitHub Actions runner image `macos-13` with `macos-15-intel` as recommended in:
* https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down
> The macOS 13 runner image will be retired by ___December 4th, 2025___.

The currently available GitHub Actions macOS runners are:
| macOS Version | macOS Name | runner.arch |
|---------------|-------------| -------------|
| ~macos-13~ | ~Ventura~ | ~X64~ |
| macos-14 | Sonoma | ARM64 |
| macos-15 | Sequoia | ARM64 |
| macos-15-intel | Sequoia | X64 |
| macos-26 | Tahoe | ARM64 |
| macos-latest | Sequoia | ARM64 |
