### PR TITLE
Get PathObservationTestCase tests to pass

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -85,7 +85,8 @@ class PathObservationTestCase(BaseTestCase):
         observer.unschedule(stream)
         observer.join()
 
-        self.assertEqual(events, [(path, self.create_and_remove_mask)])
+        # self.assertEqual(events, [(path, self.create_and_remove_mask)])
+        self.assertEqual(events, [(path, 0)])
 
     def test_multiple_files_added(self):
         events = []
@@ -131,8 +132,11 @@ class PathObservationTestCase(BaseTestCase):
                 sorted(events),
                 sorted(
                     [
-                        (path1, self.create_and_remove_mask),
-                        (path2, self.create_and_remove_mask),
+                        # (path1, self.create_and_remove_mask),
+                        # (path2, self.create_and_remove_mask),
+                        (path1, 0),
+                        (path1, 0),
+                        (path2, 0),
                     ]
                 ),
             )
@@ -186,8 +190,10 @@ class PathObservationTestCase(BaseTestCase):
         self.assertEqual(
             events,
             [
-                (path, self.create_and_remove_mask),
-                (path, self.create_and_remove_mask),
+                # (path, self.create_and_remove_mask),
+                # (path, self.create_and_remove_mask),
+                (path, 0),
+                (path, 0),
             ],
         )
 
@@ -259,7 +265,8 @@ class PathObservationTestCase(BaseTestCase):
         observer.stop()
         observer.join()
 
-        self.assertEqual(events, [(path, self.create_and_remove_mask)])
+        # self.assertEqual(events, [(path, self.create_and_remove_mask)])
+        self.assertEqual(events, [(path, 0)])
 
     def test_single_file_added_to_subdirectory(self):
         events = []
@@ -304,7 +311,8 @@ class PathObservationTestCase(BaseTestCase):
             observer.join()
 
             self.assertEqual(len(events), 1)
-            self.assertEqual(events, [(subdirectory, self.modified_mask)])
+            # self.assertEqual(events, [(subdirectory, self.modified_mask)])
+            self.assertEqual(events, [(subdirectory, 0)])
         finally:
             os.unlink(f.name)
             os.rmdir(subdirectory)
@@ -341,7 +349,8 @@ class PathObservationTestCase(BaseTestCase):
         observer.stop()
         observer.join()
 
-        self.assertEqual(events, [(path, self.create_and_remove_mask)])
+        # self.assertEqual(events, [(path, self.create_and_remove_mask)])
+        self.assertEqual(events, [(path, 0)])
 
     def test_start_then_watch(self):
         events = []
@@ -374,7 +383,8 @@ class PathObservationTestCase(BaseTestCase):
         observer.unschedule(stream)
         observer.join()
 
-        self.assertEqual(events, [(path, self.create_and_remove_mask)])
+        # self.assertEqual(events, [(path, self.create_and_remove_mask)])
+        self.assertEqual(events, [(path, 0)])
 
     def test_start_no_watch(self):
         events = []
@@ -441,8 +451,9 @@ class PathObservationTestCase(BaseTestCase):
         observer.stop()
         observer.unschedule(stream)
         observer.join()
-        self.assertEqual(len(events), 1)
-        self.assertEqual(events[0][:-1], (path1, self.create_and_remove_mask))
+        self.assertIn(len(events), (1, 2))
+        # self.assertEqual(events[0][:-1], (path1,self.create_and_remove_mask))
+        self.assertEqual(events[0][:-1], (path1, 0))
 
         # create a second file
         g.close()
@@ -460,10 +471,18 @@ class PathObservationTestCase(BaseTestCase):
         observer.unschedule(stream)
         observer.join()
 
-        self.assertEqual(len(events), 2)
-        # FIXME: why do events arrive here in reversed order?
-        self.assertEqual(events[1], (path1, self.create_and_remove_mask))
-        self.assertEqual(events[0], (path1[:-1], FS_FLAGHISTORYDONE))
+        self.assertIn(len(events), (2, 3))
+        # FIXME: why do events arrive here in reversed order??
+        if len(events) == 2:
+            self.assertEqual(
+                sorted(events),
+                sorted(((path1[:-1], FS_FLAGHISTORYDONE), (path1, 0)))
+            )
+        else:
+            self.assertEqual(
+                events,
+                [(path1, 0), (path1[:-1], FS_FLAGHISTORYDONE), (path1, 0)]
+            )
 
     def test_fileevent_stream(self):
         events = []
@@ -478,7 +497,12 @@ class PathObservationTestCase(BaseTestCase):
         f = self._make_temporary(path1)[0]
         g = self._make_temporary(path1)[0]
 
-        from fsevents import FS_CFLAGFILEEVENTS, FS_ITEMISDIR, Stream
+        from fsevents import (
+            FS_CFLAGFILEEVENTS,
+            FS_ITEMCREATED,
+            FS_ITEMISDIR,
+            Stream
+        )
 
         stream = Stream(callback, path1, flags=FS_CFLAGFILEEVENTS)
 
@@ -505,11 +529,12 @@ class PathObservationTestCase(BaseTestCase):
 
         import os
 
-        self.assertEqual(len(events), 3)
+        self.assertEqual(len(events), 4)
         self.assertEqual(
             events,
             [
-                (path1[:-1], self.create_and_remove_mask | FS_ITEMISDIR),
+                (path1[:-1], self.create_and_remove_mask),
+                (path1[:-1], FS_ITEMCREATED | FS_ITEMISDIR),
                 (f.name, self.create_and_remove_mask),
                 (g.name, self.create_and_remove_mask),
             ],


### PR DESCRIPTION
DRAFT: Do NOT merge.

The failing tests in our GitHub Actions fall under `PathObservationTestCase` in `tests.py`.

This DRAFT PR adjusts the expected values to match the actual values so we can see where things are going wrong.

This does NOT fix the tests, so it should not be merged.

---
`masks` are not being set in fsevents.